### PR TITLE
Fix complementary strands

### DIFF
--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -65,7 +65,7 @@ def create_complementary_genome(genome):
     ### all reference FASTAs written in 5'-3'
     ### this function outputs the 3'-5' complement
     for chrom in genome:
-        genome[chrom] = genome[chrom].toseq().complement()
+        genome[chrom] = genome[chrom].toseq().complement().tomutable()   ##complement() works on Seq, must be MutableSeq for write_fasta()
     return genome
 
 

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -63,7 +63,7 @@ def offset_bed(df, genome_offset):
 
 def take_complementary_bases(mutable_seq):
     ### A->T, T->A, C->G, G->C
-    complementary_sequence = mutable_seq.translate({ord("A"): "T", ord("T"): "A", ord("C"): "G", ord("G"): "C"})    
+    complementary_sequence = str(mutable_seq).translate({ord("A"): "T", ord("T"): "A", ord("C"): "G", ord("G"): "C"})    
     return complementary_sequence
 
 def create_complementary_genome(genome):

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -24,14 +24,13 @@ def write_fasta(genome, output_fasta_file):
     with open(output_fasta_file, "w") as output_handle:
         SeqIO.write(output_seqs, output_handle, "fasta")
 
+
 def remove_trailing_N_characters(sequence):
-    original_len_seq = len(sequence)
-    while sequence[0] == 'N':
-        sequence.pop(0)
-    offset = original_len_seq - len(sequence)
-    while sequence[-1] == 'N':
-        sequence.pop(-1)
-    return (sequence, offset)
+    start_index = len(sequence) - len(sequence.lstrip("N"))
+    end_index = len(sequence.rstrip("N")) #- len(sequence) - 1
+    sequence = sequence[start_index:end_index]
+    return sequence
+
 
 def read_fasta_normal(input_fasta_file):
     ### takes some time to load entire 3GB hg38 into memory; possible performance problem

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -61,16 +61,11 @@ def offset_bed(df, genome_offset):
     return df
 
 
-def take_complementary_bases(mutable_seq):
-    ### A->T, T->A, C->G, G->C
-    complementary_sequence = str(mutable_seq).translate({ord("A"): "T", ord("T"): "A", ord("C"): "G", ord("G"): "C"})    
-    return complementary_sequence
-
 def create_complementary_genome(genome):
     ### all reference FASTAs written in 5'-3'
     ### this function outputs the 3'-5' complement
     for chrom in genome:
-        genome[chrom] = take_complementary_bases(genome[chrom])
+        genome[chrom] = genome[chrom].toseq().complement()
     return genome
 
 

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -26,8 +26,8 @@ def write_fasta(genome, output_fasta_file):
 
 
 def remove_trailing_N_characters(sequence):
-    start_index = len(sequence) - len(sequence.lstrip("N"))
-    end_index = len(sequence.rstrip("N")) #- len(sequence) - 1
+    start_index = len(str(sequence)) - len(str(sequence).lstrip("N"))
+    end_index = len(str(sequence).rstrip("N")) #- len(sequence) - 1
     sequence = sequence[start_index:end_index]
     return sequence
 

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -29,7 +29,8 @@ def remove_trailing_N_characters(sequence):
     start_index = len(str(sequence)) - len(str(sequence).lstrip("N"))
     end_index = len(str(sequence).rstrip("N")) #- len(sequence) - 1
     sequence = sequence[start_index:end_index]
-    return sequence
+    offset = start_index
+    return (sequence, offset)
 
 
 def read_fasta_normal(input_fasta_file):


### PR DESCRIPTION

(1) Cannot use `.translate()` on a MutableSeq object

(2) BioPython's `.complement()` works very quickly