### PR TITLE
re-fixed issue with function remove_trailing_N_characters()

### DIFF
--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -80,9 +80,9 @@ class Mutation_Orchestrator:
 
     # Models exponential decay, discretely
     # Expected value of event is 1/p
-    def get_event_length(self, p=0.6):
-        z = np.random.geometric(p)
-        return z
+    def get_event_length(self, p=0.6, number = 1):
+        z = np.random.geometric(p, size=number)
+        return z[0]
 
     # Duplication currently only goes one direction (forward)
     # Creates a variable amount of duplications (num_duplications, drawn from geometric dist)

--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -82,7 +82,7 @@ class Mutation_Orchestrator:
     # Expected value of event is 1/p
     def get_event_length(self, p=0.6):
         z = np.random.geometric(p)
-        return z[0]
+        return z
 
     # Duplication currently only goes one direction (forward)
     # Creates a variable amount of duplications (num_duplications, drawn from geometric dist)

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -18,15 +18,13 @@ def write_fasta(genome, output_fasta_file):
         SeqIO.write(output_seqs, output_handle, "fasta")
 
 def remove_trailing_N_characters(sequence):
-    """ Strings representing the nucleotides typically start and end with 
-        repeating sequences of the 'N' character. This function strips them 
-        from the right and left side of the input sequence. """ 
-    original_len_seq = len(sequence)
-    while sequence[0] == 'N':
-        sequence.pop(0)
-    offset = original_len_seq - len(sequence)
-    while sequence[-1] == 'N':
-        sequence.pop(-1)
+    """ Strings representing the nucleotides typically start and end with
+        repeating sequences of the 'N' character. This function strips them
+        from the right and left side of the input sequence. """
+    start_index = len(str(sequence)) - len(str(sequence).lstrip("N"))
+    end_index = len(str(sequence).rstrip("N"))
+    sequence = sequence[start_index:end_index]
+    offset = start_index
     return (sequence, offset)
 
 def read_fasta_normal(input_fasta_file):


### PR DESCRIPTION
Somehow, the old buggy version of function remove_trailing_N_characters() in simulate_endToEnd.py ended up in the latest master branch.

Fixes this. 

PS: I had forgotten I had an old branch named " fix_remove_trailing_N_characters". This branch/pull request more sensible with respect to master. 