### PR TITLE
Passing args zero

### DIFF
--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -76,8 +76,11 @@ def main(args):
     orchestrator.generate_indels(mutated_genome, args['number_indels'])
     (mutated_genome, snv_and_indel_bed) = orchestrator.generate_fasta_and_bed(mutated_genome)
     ### write out "normalsim" bedpe and fasta
-    write_fasta(mutated_genome, args['output_normal_fasta'])
-    write_bed(genome_offset, snv_and_indel_bed, args['output_normal_bedfile'])  
+    if ((args['number_snvs']==0) & (args['number_indels']==0)):
+        pass
+    else:
+        write_fasta(mutated_genome, args['output_normal_fasta'])
+        write_bed(genome_offset, snv_and_indel_bed, args['output_normal_bedfile'])  
 
     ## output complement 3'-5' strand normal
     normal_complement = create_complementary_genome(mutated_genome)

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -87,11 +87,15 @@ def main(args):
     write_fasta(normal_complement, args['output_complement_normal_fasta'])
     del normal_complement
 
+ 
     # add structural varations
-    orchestrator.generate_structural_variations(mutated_genome, args['number_of_tumorSVs'])
-    (mutated_genome, tumor_bed) = orchestrator.generate_fasta_and_bed(mutated_genome)
-    write_fasta(mutated_genome, args['output_tumor_fasta'])
-    write_bed(genome_offset, tumor_bed, args['output_tumor_bedfile'])  ### write out "tumorsim" bedpe
+    if (args['number_of_tumorSVs']==0):
+        pass
+    else:
+        orchestrator.generate_structural_variations(mutated_genome, args['number_of_tumorSVs'])
+        (mutated_genome, tumor_bed) = orchestrator.generate_fasta_and_bed(mutated_genome)
+        write_fasta(mutated_genome, args['output_tumor_fasta'])
+        write_bed(genome_offset, tumor_bed, args['output_tumor_bedfile'])  ### write out "tumorsim" bedpe
 
     ## output complement 3'-5' strand tumor
     tumor_complement = create_complementary_genome(mutated_genome)


### PR DESCRIPTION
CC @nickdeveaux 

We should create checks if args passed are 0. If `number_snvs` and `number_indels` are both zero or if `number_of_tumorSVs` is 0, there will be a ValueError. The following fix may not be the best solution. 

Error from certain combinations of args inputs = 0:
```
Traceback (most recent call last):
  File "simulate_endToEnd.py", line 144, in <module>
    main(args)
  File "simulate_endToEnd.py", line 87, in main
    (mutated_genome, snv_and_indel_bed) = orchestrator.generate_fasta_and_bed(mutated_genome)
  File "~/lib/mutation_orchestrator.py", line 130, in generate_fasta_and_bed
    (genome, log_data_frame) =  self.tracker.collapse_list(genome)
  File "~/lib/mutation_tracker.py", line 60, in collapse_list
    log_data_frame.columns = ['chrom', 'start', 'end', 'name', 'alt', 'uid']
  File "~/lib/python3.5/site-packages/pandas/core/generic.py", line 2757, in __setattr__
    return object.__setattr__(self, name, value)
  File "pandas/src/properties.pyx", line 65, in pandas.lib.AxisProperty.__set__ (pandas/lib.c:46249)
  File "~/lib/python3.5/site-packages/pandas/core/generic.py", line 448, in _set_axis
    self._data.set_axis(axis, labels)
  File "~/lib/python3.5/site-packages/pandas/core/internals.py", line 2802, in set_axis
    (old_len, new_len))
```