### PR TITLE
Add chromothripsis

### DIFF
--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -162,7 +162,7 @@ class Mutation_Orchestrator:
                 self.structural_variations[variation](genome, chromothripsis=True, list_of_reserved_chroms = list_of_reserved_chroms)
 
                 
-    def generate_chromothripsis(self, genome, chromosome, number_of_chromothriptic_rearrangements):  ## not including inversions; number_of_chromothriptic_rearrangements from probabilities_config.py
+    def generate_chromothripsis(self, genome, chromosome, number_of_chromothriptic_rearrangements):  ## not including insertions; number_of_chromothriptic_rearrangements from probabilities_config.py
         variations = np.random.choice(list(chromothripsis_probabilities.keys()),
                                       number_of_chromothriptic_rearrangements, chromothripsis_probabilities.values())
         for variation in variations:

--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -49,19 +49,32 @@ class Mutation_Orchestrator:
         else:
             raise NotImplementedError("Only Uniform is implemented!")
 
+
+### stuff == check list of reserved chromsomes. while chrom in rese
+
     # Default to being a big deletion, but p=0.6 makes it a small deletion
-    def orchestrate_deletion(self, genome, distribution='uniform', p=0.001, fixed_chrom=None):
-        if fixed_chrom == None:
+    def orchestrate_deletion(self, genome, distribution='uniform', p=0.001, fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
+        if ((fixed_chrom == None) & (chromothripsis=True)):
             chrom = self.pick_chromosomes(genome, number = 1)[0]
+            while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
+                chrom = self.pick_chromosomes(genome, number = 1)[0]
+        elif fixed_chrom == None:
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
+        else:
+            chrom = fixed_chrom
         start = self.get_location_on_sequence(genome[chrom])
         end = self.get_end_of_event(start, genome[chrom], p)
         self.tracker.create_deletion(chrom, start, end)
         logging.info('Orchestrated deletion from {} to {} in chrom {}'.format(start, end, chrom))
 
-    def orchestrate_translocation(self, genome, distribution='uniform', fixed_chrom=None):
+    def orchestrate_translocation(self, genome, distribution='uniform', fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
         if len(genome) == 1:
             return
-        if fixed_chrom == None:
+        if ((fixed_chrom == None) & (chromothripsis=True)):
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
+            while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
+                chrom = self.pick_chromosomes(genome, number = 1)[0]
+        elif fixed_chrom == None:
             (chrom_source, chrom_target) = self.pick_chromosomes(genome, number = 2, replace=False)
         else:
             chrom_source = fixed_chrom
@@ -77,21 +90,14 @@ class Mutation_Orchestrator:
         logging.info('Orchestrated translocation at position {} to position {} on chrom {} at position {} to position {} on chrom {}'.format(
             start_source, end_source, chrom_source, start_target, end_target, chrom_target))
 
-    # Guarantees the end of the event isn't outside the sequence
-    def get_end_of_event(self, start_pos, seq, p):
-        length = self.get_event_length(p)
-        return np.min([start_pos + length, len(seq)])
-
-    # Models exponential decay, discretely
-    # Expected value of event is 1/p
-    def get_event_length(self, p=0.6, number = 1):
-        z = np.random.geometric(p, size=number)
-        return z[0]
-
     # Duplication currently only goes one direction (forward)
     # Creates a variable amount of duplications (num_duplications, drawn from geometric dist)
-    def orchestrate_duplication(self, genome, distribution='uniform', fixed_chrom=None):
-        if fixed_chrom == None:
+    def orchestrate_duplication(self, genome, distribution='uniform', fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
+        if ((fixed_chrom == None) & (chromothripsis=True)):
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
+            while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
+                chrom = self.pick_chromosomes(genome, number = 1)[0]
+        elif fixed_chrom == None:
             chrom = self.pick_chromosomes(genome, number = 1)[0]
         else:
             chrom = fixed_chrom
@@ -103,8 +109,12 @@ class Mutation_Orchestrator:
              name='duplication (times {})'.format(num_duplications))
         logging.info('Orchestrated duplication at po`tion {} to {} on chrom {}'.format(start, end, chrom))
 
-    def orchestrate_inversion(self, genome, distribution='uniform', fixed_chrom=None):
-        if fixed_chrom == None:
+    def orchestrate_inversion(self, genome, distribution='uniform', fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
+        if ((fixed_chrom == None) & (chromothripsis=True)):
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
+            while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
+                chrom = self.pick_chromosomes(genome, number = 1)[0]
+        elif fixed_chrom == None:
             chrom = self.pick_chromosomes(genome, number = 1)[0]
         else:
             chrom = fixed_chrom
@@ -113,8 +123,12 @@ class Mutation_Orchestrator:
         self.tracker.create_inversion(chrom, start, end)
         logging.info('Orchestrated inversion at position {} to {} on chrom {}'.format(start, end, chrom))
 
-    def orchestrate_insertion(self, genome, distribution='uniform', p=0.001, fixed_chrom=None):
-        if fixed_chrom == None:
+    def orchestrate_insertion(self, genome, distribution='uniform', p=0.001, fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
+        if ((fixed_chrom == None) & (chromothripsis=True)):
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
+            while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
+                chrom = self.pick_chromosomes(genome, number = 1)[0]
+        elif fixed_chrom == None:
             chrom = self.pick_chromosomes(genome, number = 1)[0]
         else:
             chrom = fixed_chrom
@@ -125,6 +139,17 @@ class Mutation_Orchestrator:
         self.tracker.create_insertion(chrom, start, new_seq)
         logging.info('Orchestrated insertion at position {} on chrom {} adding bases from position {} to {}'.format(start,
          chrom, new_seq_start, new_seq_end))
+
+    # Guarantees the end of the event isn't outside the sequence
+    def get_end_of_event(self, start_pos, seq, p):
+        length = self.get_event_length(p)
+        return np.min([start_pos + length, len(seq)])
+    
+    # Models exponential decay, discretely
+    # Expected value of event is 1/p
+    def get_event_length(self, p=0.6, number = 1):
+        z = np.random.geometric(p, size=number)
+        return z[0]
 
     def generate_structural_variations(self, genome, number):
         variations = np.random.choice(list(structural_variations_probabilities.keys()),

--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -3,7 +3,7 @@ import numpy as np
 from mutation_creator import Mutation_Creator
 from mutation_tracker import Mutation_Tracker
 import logging
-from probabilities_config import structural_variations_probabilities, snv_probabilities
+from probabilities_config import structural_variations_probabilities, snv_probabilities, chromothripsis_probabilities, number_of_chromothriptic_rearrangements
 
 class Mutation_Orchestrator:
     """ Mutation_Orchestrator is a class that operates on a genome to make a mutation.
@@ -116,6 +116,12 @@ class Mutation_Orchestrator:
     def generate_structural_variations(self, genome, number):
         variations = np.random.choice(list(structural_variations_probabilities.keys()),
                 number, structural_variations_probabilities.values())
+        for variation in variations:
+            self.structural_variations[variation](genome)
+
+def generate_chromothripsis(self, genome, number = number_of_chromothriptic_rearrangements):  ## not including inversions
+        variations = np.random.choice(list(chromothripsis_probabilities.keys()),
+                                  number, chromothripsis_probabilities.values())
         for variation in variations:
             self.structural_variations[variation](genome)
 

--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -54,7 +54,7 @@ class Mutation_Orchestrator:
 
     # Default to being a big deletion, but p=0.6 makes it a small deletion
     def orchestrate_deletion(self, genome, distribution='uniform', p=0.001, fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
-        if ((fixed_chrom == None) & (chromothripsis=True)):
+        if ((fixed_chrom == None) & (chromothripsis==True)):
             chrom = self.pick_chromosomes(genome, number = 1)[0]
             while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
                 chrom = self.pick_chromosomes(genome, number = 1)[0]
@@ -70,7 +70,7 @@ class Mutation_Orchestrator:
     def orchestrate_translocation(self, genome, distribution='uniform', fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
         if len(genome) == 1:
             return
-        if ((fixed_chrom == None) & (chromothripsis=True)):
+        if ((fixed_chrom == None) & (chromothripsis==True)):
             chrom = self.pick_chromosomes(genome, number = 1)[0]
             while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
                 chrom = self.pick_chromosomes(genome, number = 1)[0]
@@ -93,7 +93,7 @@ class Mutation_Orchestrator:
     # Duplication currently only goes one direction (forward)
     # Creates a variable amount of duplications (num_duplications, drawn from geometric dist)
     def orchestrate_duplication(self, genome, distribution='uniform', fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
-        if ((fixed_chrom == None) & (chromothripsis=True)):
+        if ((fixed_chrom == None) & (chromothripsis==True)):
             chrom = self.pick_chromosomes(genome, number = 1)[0]
             while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
                 chrom = self.pick_chromosomes(genome, number = 1)[0]
@@ -110,7 +110,7 @@ class Mutation_Orchestrator:
         logging.info('Orchestrated duplication at po`tion {} to {} on chrom {}'.format(start, end, chrom))
 
     def orchestrate_inversion(self, genome, distribution='uniform', fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
-        if ((fixed_chrom == None) & (chromothripsis=True)):
+        if ((fixed_chrom == None) & (chromothripsis==True)):
             chrom = self.pick_chromosomes(genome, number = 1)[0]
             while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
                 chrom = self.pick_chromosomes(genome, number = 1)[0]
@@ -124,7 +124,7 @@ class Mutation_Orchestrator:
         logging.info('Orchestrated inversion at position {} to {} on chrom {}'.format(start, end, chrom))
 
     def orchestrate_insertion(self, genome, distribution='uniform', p=0.001, fixed_chrom=None, chromothripsis=False, list_of_reserved_chroms=None):
-        if ((fixed_chrom == None) & (chromothripsis=True)):
+        if ((fixed_chrom == None) & (chromothripsis==True)):
             chrom = self.pick_chromosomes(genome, number = 1)[0]
             while chrom in list_of_reserved_chroms:                        ### if chromothripsis, check to make sure random chromosomes are not in list of chromothripsis chromosomes.
                 chrom = self.pick_chromosomes(genome, number = 1)[0]
@@ -157,11 +157,11 @@ class Mutation_Orchestrator:
         for variation in variations:
             self.structural_variations[variation](genome)
 
-    def generate_chromothripsis(self, genome, number = number_of_chromothriptic_rearrangements):  ## not including inversions
+    def generate_chromothripsis(self, genome, chromosome, number = number_of_chromothriptic_rearrangements):  ## not including inversions; number_of_chromothriptic_rearrangements from probabilities_config.py
         variations = np.random.choice(list(chromothripsis_probabilities.keys()),
                                   number, chromothripsis_probabilities.values())
         for variation in variations:
-            self.structural_variations[variation](genome)
+            self.structural_variations[variation](genome, fixed_chrom = chromosome, chromothripsis=True)
 
     # Create small insertions and small deletions
     def generate_indels(self, genome, number):

--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -152,19 +152,19 @@ class Mutation_Orchestrator:
     def generate_structural_variations(self, genome, number, chromothripsis=False, list_of_reserved_chroms=None):
         if chromothripsis == False:
             variations = np.random.choice(list(structural_variations_probabilities.keys()),
-                    number, structural_variations_probabilities.values())
+                                          number, structural_variations_probabilities.values())
             for variation in variations:
                 self.structural_variations[variation](genome)
         elif chromothripsis == True:
             variations = np.random.choice(list(structural_variations_probabilities.keys()),
-                    number, structural_variations_probabilities.values()
+                                          number, structural_variations_probabilities.values())
             for variation in variations:
                 self.structural_variations[variation](genome, chromothripsis=True, list_of_reserved_chroms)
 
                 
     def generate_chromothripsis(self, genome, chromosome, number_of_chromothriptic_rearrangements):  ## not including inversions; number_of_chromothriptic_rearrangements from probabilities_config.py
         variations = np.random.choice(list(chromothripsis_probabilities.keys()),
-                                  number_of_chromothriptic_rearrangements, chromothripsis_probabilities.values())
+                                      number_of_chromothriptic_rearrangements, chromothripsis_probabilities.values())
         for variation in variations:
             self.structural_variations[variation](genome, fixed_chrom = chromosome, chromothripsis=True)   ## pass in a single chromosome for chromothripsis
 

--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -159,7 +159,7 @@ class Mutation_Orchestrator:
             variations = np.random.choice(list(structural_variations_probabilities.keys()),
                                           number, structural_variations_probabilities.values())
             for variation in variations:
-                self.structural_variations[variation](genome, chromothripsis=True, list_of_reserved_chroms)
+                self.structural_variations[variation](genome, chromothripsis=True, list_of_reserved_chroms = list_of_reserved_chroms)
 
                 
     def generate_chromothripsis(self, genome, chromosome, number_of_chromothriptic_rearrangements):  ## not including inversions; number_of_chromothriptic_rearrangements from probabilities_config.py

--- a/lib/mutation_orchestrator.py
+++ b/lib/mutation_orchestrator.py
@@ -36,7 +36,7 @@ class Mutation_Orchestrator:
     def pick_chromosomes(self, genome, number=1, replace=True):
         relative_lengths = np.array([len(genome[x]) for x in genome])
         probabilities = relative_lengths / float(relative_lengths.sum())
-        chroms = np.random.choice(list(genome.keys()), number, replace=replace ,p=probabilities.tolist())
+        chroms = np.random.choice(list(genome.keys()), number, replace=replace, p=probabilities.tolist())
         return chroms
 
     def get_location_on_sequence(self, seq, distribution='uniform'):
@@ -50,18 +50,22 @@ class Mutation_Orchestrator:
             raise NotImplementedError("Only Uniform is implemented!")
 
     # Default to being a big deletion, but p=0.6 makes it a small deletion
-    def orchestrate_deletion(self, genome, distribution='uniform', p=0.001):
-        chrom = self.pick_chromosomes(genome)[0]
+    def orchestrate_deletion(self, genome, distribution='uniform', p=0.001, fixed_chrom=None):
+        if fixed_chrom == None:
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
         start = self.get_location_on_sequence(genome[chrom])
         end = self.get_end_of_event(start, genome[chrom], p)
         self.tracker.create_deletion(chrom, start, end)
         logging.info('Orchestrated deletion from {} to {} in chrom {}'.format(start, end, chrom))
 
-    def orchestrate_translocation(self, genome, distribution='uniform'):
+    def orchestrate_translocation(self, genome, distribution='uniform', fixed_chrom=None):
         if len(genome) == 1:
-            print('No translocations allowed: genome too small')
             return
-        (chrom_source, chrom_target) = self.pick_chromosomes(genome, number = 2, replace = False)
+        if fixed_chrom == None:
+            (chrom_source, chrom_target) = self.pick_chromosomes(genome, number = 2, replace=False)
+        else:
+            chrom_source = fixed_chrom
+            chrom_target = fixed_chrom
         start_source = self.get_location_on_sequence(genome[chrom_source])
         start_target = self.get_location_on_sequence(genome[chrom_target])
         end_source = self.get_end_of_event(start_source, genome[chrom_source], p=0.001)
@@ -86,8 +90,11 @@ class Mutation_Orchestrator:
 
     # Duplication currently only goes one direction (forward)
     # Creates a variable amount of duplications (num_duplications, drawn from geometric dist)
-    def orchestrate_duplication(self, genome, distribution='uniform'):
-        chrom = self.pick_chromosomes(genome, number = 1)[0]
+    def orchestrate_duplication(self, genome, distribution='uniform', fixed_chrom=None):
+        if fixed_chrom == None:
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
+        else:
+            chrom = fixed_chrom
         start = self.get_location_on_sequence(genome[chrom])
         end = self.get_end_of_event(start, genome[chrom], p=0.001)
         num_duplications = self.get_event_length(p=0.6) # exponential ranging from 1 to 10
@@ -96,15 +103,21 @@ class Mutation_Orchestrator:
              name='duplication (times {})'.format(num_duplications))
         logging.info('Orchestrated duplication at po`tion {} to {} on chrom {}'.format(start, end, chrom))
 
-    def orchestrate_inversion(self, genome, distribution='uniform'):
-        chrom = self.pick_chromosomes(genome, number = 1)[0]
+    def orchestrate_inversion(self, genome, distribution='uniform', fixed_chrom=None):
+        if fixed_chrom == None:
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
+        else:
+            chrom = fixed_chrom
         start = self.get_location_on_sequence(genome[chrom])
         end = self.get_end_of_event(start, genome[chrom], p=0.001)
         self.tracker.create_inversion(chrom, start, end)
         logging.info('Orchestrated inversion at position {} to {} on chrom {}'.format(start, end, chrom))
 
-    def orchestrate_insertion(self, genome, distribution='uniform', p=0.001):
-        chrom = self.pick_chromosomes(genome, number = 1)[0]
+    def orchestrate_insertion(self, genome, distribution='uniform', p=0.001, fixed_chrom=None):
+        if fixed_chrom == None:
+            chrom = self.pick_chromosomes(genome, number = 1)[0]
+        else:
+            chrom = fixed_chrom
         start = self.get_location_on_sequence(genome[chrom])
         new_seq_start = self.get_location_on_sequence(genome[chrom])
         new_seq_end = self.get_end_of_event(new_seq_start, genome[chrom], p)
@@ -119,7 +132,7 @@ class Mutation_Orchestrator:
         for variation in variations:
             self.structural_variations[variation](genome)
 
-def generate_chromothripsis(self, genome, number = number_of_chromothriptic_rearrangements):  ## not including inversions
+    def generate_chromothripsis(self, genome, number = number_of_chromothriptic_rearrangements):  ## not including inversions
         variations = np.random.choice(list(chromothripsis_probabilities.keys()),
                                   number, chromothripsis_probabilities.values())
         for variation in variations:

--- a/lib/probabilities_config.py
+++ b/lib/probabilities_config.py
@@ -12,3 +12,12 @@ snv_probabilities = {
     'T':.25,
     'G':.25
 }
+chromothripsis_probabilities = {
+    'deletion': 0.2,
+    'translocation': 0.2,
+    'duplication' : 0.2,
+    'inversion' : 0.2,
+    'insertion' : 0.2,
+}
+
+number_of_chromothripsis_events = 100

--- a/lib/probabilities_config.py
+++ b/lib/probabilities_config.py
@@ -13,11 +13,10 @@ snv_probabilities = {
     'G':.25
 }
 chromothripsis_probabilities = {
-    'deletion': 0.2,
-    'translocation': 0.2,
-    'duplication' : 0.2,
-    'inversion' : 0.2,
-    'insertion' : 0.2,
+    'deletion': 0.25,
+    'translocation': 0.25,
+    'duplication' : 0.25,
+    'inversion' : 0.25,
 }
 
-number_of_chromothripsis_events = 100
+number_of_chromothriptic_rearrangements = 100

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -1,6 +1,7 @@
 from Bio import SeqIO
 from mutation_orchestrator import Mutation_Orchestrator
 import copy
+import numpy as np
 import pandas as pd
 import re
 import argparse

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -67,18 +67,42 @@ def create_complementary_genome(genome):
     return new_genome
 
 ## exception check for argparse, chromothripsis
-### QUESITON: given this function, how should I restrict chromosomes w/r.t. BFBs?
 def check_chromothripsis_arg(value):
     ivalue = int(value)
     if ivalue > 24:
         raise argparse.ArgumentTypeError("%s is an invalid number of chromosomes for --chromothripsis_number_of_chroms" % value)
     return ivalue
 
+def reserve_chromothripsis_chromosomes(genome, number):
+    for i in range(args['chromothripsis_number_of_chroms']):
+    ##
+    ## randomly pick chromosome
+    ## check if chromosome in reserved list
+    ## if not in reserved list, then add to list
+   ### if in reserved list, then randomly pick again
+
+
+
+### Now, feed in list to chromosthirpsis, with events only happening at that list
+
+## SV events below must ignore these chromosomes
+## flag: if chromothripsis, then check whether reserved chromosome is in the list. If so, ignore
+
+### should re-write, as need to check list whether a chromosome is reserved or not
+def pick_chromosomes(self, genome, number=1, replace=True):
+    relative_lengths = np.array([len(genome[x]) for x in genome])
+    probabilities = relative_lengths / float(relative_lengths.sum())
+    chroms = np.random.choice(list(genome.keys()), number, replace=replace ,p=probabilities.tolist())
+    return chroms
+
+### black list these chromosomes
+
 
 def main(args):
      # read genome fasta
     (mutated_genome, genome_offset) = read_fasta_normal(args['input_fasta'])
 
+    ## normal
     orchestrator = Mutation_Orchestrator()
     # add germilne SNVs & InDels
     mutated_genome = orchestrator.snv_fast(mutated_genome, args['number_snvs'])
@@ -93,6 +117,11 @@ def main(args):
     write_fasta(normal_complement, args['output_complement_normal_fasta'])
     del normal_complement
 
+
+    ## tumor
+    reserved_chroms = []
+    
+    
     # add structural varations
     orchestrator.generate_structural_variations(mutated_genome, args['number_of_tumorSVs'])
     (mutated_genome, tumor_bed) = orchestrator.generate_fasta_and_bed(mutated_genome)

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -73,13 +73,31 @@ def check_chromothripsis_arg(value):
         raise argparse.ArgumentTypeError("%s is an invalid number of chromosomes for --chromothripsis_number_of_chroms" % value)
     return ivalue
 
-def reserve_chromothripsis_chromosomes(genome, number):
+
+### bad form, taken directly from `mutation_orchestrator.py`
+
+def pick_chromosomes(self, genome, number=1, replace=True):
+    relative_lengths = np.array([len(genome[x]) for x in genome])
+    probabilities = relative_lengths / float(relative_lengths.sum())
+    chroms = np.random.choice(list(genome.keys()), number, replace=replace ,p=probabilities.tolist())
+    return chroms
+
+
+##
+## randomly pick chromosome
+## check if chromosome in reserved list
+## if not in reserved list, then add to list
+### if in reserved list, then randomly pick again
+
+def reserve_chromothripsis_chromosomes(genome, list_of_reserved_chroms):
     for i in range(args['chromothripsis_number_of_chroms']):
-    ##
-    ## randomly pick chromosome
-    ## check if chromosome in reserved list
-    ## if not in reserved list, then add to list
-   ### if in reserved list, then randomly pick again
+        chosen_chrom = pick_chromosomes(genome, number=1)
+        if chosen_chrom not in list_of_reserved_chroms:
+            list_of_reserved_chroms.append(chosen_chrom)
+        else:
+            while chosen_chrom in list_of_reserved_chroms:
+                chosen_chrom = pick_chromosomes(genome, number=1)  ## if the chromosome is already in the list, pick again---better than a while True loop
+
 
 
 
@@ -88,14 +106,13 @@ def reserve_chromothripsis_chromosomes(genome, number):
 ## SV events below must ignore these chromosomes
 ## flag: if chromothripsis, then check whether reserved chromosome is in the list. If so, ignore
 
-### should re-write, as need to check list whether a chromosome is reserved or not
 def pick_chromosomes(self, genome, number=1, replace=True):
     relative_lengths = np.array([len(genome[x]) for x in genome])
     probabilities = relative_lengths / float(relative_lengths.sum())
     chroms = np.random.choice(list(genome.keys()), number, replace=replace ,p=probabilities.tolist())
     return chroms
 
-### black list these chromosomes
+
 
 
 def main(args):

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -29,7 +29,7 @@ def remove_trailing_N_characters(sequence):
 
 def read_fasta_normal(input_fasta_file):
     """ Read in an input fasta file that represents a normal (non-cancerous) genome 
-        It takes some time to load entire 3GB hg38 into memory; possible performance problem """
+        It takes some time to load entire 3GB hg38 into memory """
     genome = {}
     genome_offset = {}
     for seq_record in SeqIO.parse(input_fasta_file, "fasta"):
@@ -64,7 +64,16 @@ def create_complementary_genome(genome):
     new_genome = copy.deepcopy(genome)
     for chrom in new_genome:
         new_genome[chrom].complement()
-    return new_genome 
+    return new_genome
+
+## exception check for argparse, chromothripsis
+### QUESITON: given this function, how should I restrict chromosomes w/r.t. BFBs?
+def check_chromothripsis_arg(value):
+    ivalue = int(value)
+    if ivalue > 24:
+        raise argparse.ArgumentTypeError("%s is an invalid number of chromosomes for --chromothripsis_number_of_chroms" % value)
+    return ivalue
+
 
 def main(args):
      # read genome fasta
@@ -121,6 +130,10 @@ if __name__ == "__main__":
     parser.add_argument('--number_of_tumorSVs',
                         default = 10000,
                         help="number of structural variations to add to the tumor genome")
+    parser.add_argument('--chromothripsis_number_of_chroms',
+                        default = 1,
+                        help="number of chromosome-wide chromthriptic events to add to the tumor genome",
+                        type=check_chromothripsis_arg)
     parser.add_argument('--output_normal_bedfile',
                         default = "outputs/normal.bed",
                         help='file path for the output normal (SNV-added) bedfile')

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -106,11 +106,6 @@ def reserve_chromothripsis_chromosomes(genome, list_of_reserved_chroms):
 ## SV events below must ignore these chromosomes
 ## flag: if chromothripsis, then check whether reserved chromosome is in the list. If so, ignore
 
-def pick_chromosomes(self, genome, number=1, replace=True):
-    relative_lengths = np.array([len(genome[x]) for x in genome])
-    probabilities = relative_lengths / float(relative_lengths.sum())
-    chroms = np.random.choice(list(genome.keys()), number, replace=replace ,p=probabilities.tolist())
-    return chroms
 
 
 

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -111,6 +111,8 @@ def reserve_chromothripsis_chromosomes(genome, list_of_reserved_chroms):
 
 
 def main(args):
+    
+    reserved_chroms = []
      # read genome fasta
     (mutated_genome, genome_offset) = read_fasta_normal(args['input_fasta'])
 
@@ -172,7 +174,7 @@ if __name__ == "__main__":
                         default = 10000,
                         help="number of structural variations to add to the tumor genome")
     parser.add_argument('--chromothripsis_number_of_chroms',
-                        default = 1,
+                        default = None,
                         help="number of chromosome-wide chromthriptic events to add to the tumor genome",
                         type=check_chromothripsis_arg)
     parser.add_argument('--output_normal_bedfile',

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -134,7 +134,7 @@ def main(args):
     
     # add structural varations
     if args['chromothripsis_number_of_chroms'] is not None:                  ## chromothripsis = TRUE
-        orchestrator.generate_structural_variations(mutated_genome, args['number_of_tumorSVs'], chromothripsis=True, list_of_reserved_chroms)
+        orchestrator.generate_structural_variations(mutated_genome, args['number_of_tumorSVs'], chromothripsis=True, list_of_reserved_chroms=reserved_chroms)
         (mutated_genome, tumor_bed) = orchestrator.generate_fasta_and_bed(mutated_genome)
         write_fasta(mutated_genome, args['output_tumor_fasta'])
         write_bed(genome_offset, tumor_bed, args['output_tumor_bedfile'])  ### write out "tumorsim" bedpe

--- a/lib/simulate_endToEnd.py
+++ b/lib/simulate_endToEnd.py
@@ -76,7 +76,7 @@ def check_chromothripsis_arg(value):
 
 ### bad form, taken directly from `mutation_orchestrator.py`
 
-def pick_chromosomes(self, genome, number=1, replace=True):
+def pick_chromosomes(genome, number=1, replace=True):
     relative_lengths = np.array([len(genome[x]) for x in genome])
     probabilities = relative_lengths / float(relative_lengths.sum())
     chroms = np.random.choice(list(genome.keys()), number, replace=replace, p=probabilities.tolist())

--- a/lib/tests/test_simulate_endToEnd.py
+++ b/lib/tests/test_simulate_endToEnd.py
@@ -83,6 +83,7 @@ class TestSimulateNormal(unittest.TestCase):
                     args['number_snvs'] = 1
                     args['number_indels'] = 1
                     args['number_of_tumorSVs'] = 1
+                    args['chromothripsis_number_of_chroms'] = 1
                     args['output_normal_bedfile'] = "test_output/normal.bed"
                     args['output_tumor_bedfile'] = "test_output/tumor.bed"
                     args['output_tumor_fasta'] = "test_output/tumorsim.fasta"

--- a/lib/tests/test_simulate_endToEnd.py
+++ b/lib/tests/test_simulate_endToEnd.py
@@ -132,6 +132,7 @@ class TestSimulateNormal(unittest.TestCase):
                     args['number_snvs'] = 1
                     args['number_indels'] = 1
                     args['number_of_tumorSVs'] = 1
+                    args['chromothripsis_number_of_chroms'] = 1
                     args['output_normal_bedfile'] = "test_output/normal.bed"
                     args['output_tumor_bedfile'] = "test_output/tumor.bed"
                     args['output_tumor_fasta'] = "test_output/tumorsim.fasta"


### PR DESCRIPTION
Well, it looks like this passes. I'm still skeptical, but...

If so, then this branch should create chromothripsis. One reserves entire chromosomes to be rearranged with SVs (except no insertions). 

One then creates no more SVs in these chromosomes---users will know there could be issues with the coordinate system. 

In this case, I would be interested in creating an log file only for "chromothriptic rearrangements" for each chromosome, possibly using our existing infrastructure and `import logging`. Talk to Nick about this. I suspect it's straightforward to do---log the events in the order they take place, and allow users to "work backwards" if they are so inclined.

reference: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3065307/
Based on Stephens et al 2011, it looks like chromothripsis happening on 20-200Kb. I believe this is the current length scale, but users could crank this up/down via the probability parameter. 
