### PR TITLE
added fix to create_snv()

### DIFF
--- a/lib/mutation_creator.py
+++ b/lib/mutation_creator.py
@@ -11,7 +11,14 @@ class Mutation_Creator:
         return new_seq
 
     def create_snv(self, mutable_seq, start, new_base):
-        mutable_seq[start] = new_base
+        ref = mutable_seq[start]
+        if ref != new_base:
+            mutable_seq[start] = new_base
+        else:
+            new_base = get_genuine_alt(ref)
+            mutable_seq[start] = new_base
+        del ref
+        del new_base
         return mutable_seq
 
     def create_insertion(self, mutable_seq, start, new_seq):
@@ -32,3 +39,12 @@ class Mutation_Creator:
         new_seq2 = self.create_deletion(seq2, start2,start2+length2)
         new_seq2 = self.create_insertion(new_seq2, start2, seq1[start1:start1+length1])
         return (new_seq1, new_seq2)
+
+
+def get_genuine_alt(incorrect_snp):
+    """ Convert REF base to ALT base such that REF != ALT"""
+    bases = set('ATCG')
+    legend = {base:list(bases - set(base)) for base in bases}  ## key-value legend, `{'C': ['T', 'A', 'G'], ...`
+    alt = random.choice(legend[incorrect_snp])
+    return alt
+


### PR DESCRIPTION
So, it appears that the `master` branch for `create_snv()` will add SNPs which are the same base as REF, i.e. REF==ALT. That's a problem---previously, we never checked whether we were adding bases that we of the same identity as the reference. 

One option is to re-write `create_snv()` such that it doesn't take `new_base` as an argument. The function would automatically grab a base not its identity using a dictionary (similar to what's been implemented here). The downside to this is that user's cannot set base probabilities. 

A second option is to do what's been implemented here. This will naturally slow down `snv_fast()` but it shouldn't make a huge difference. 